### PR TITLE
#170947395 Users should be able to search 

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,8 @@
       "!src/redux/actions/*",
       "!src/stories/*",
       "!src/components/AddAccommodationForm.js",
+      "!src/components/RequestsTable.js",
+      "!src/components/DrawerComponents.js",
       "!src/views/Dashboard/addAccommodationPage.js",
       "!src/views/Message.js",
       "!src/helpers/*",

--- a/src/__tests__/__snapshots__/dashbaord.requests.spec.js.snap
+++ b/src/__tests__/__snapshots__/dashbaord.requests.spec.js.snap
@@ -54,7 +54,59 @@ exports[`LOST should render requestsComponent component 1`] = `
             class="MuiTypography-root MuiTypography-h6"
             id="tableTitle"
           >
-            My requests
+            My request
+          </div>
+          <div
+            class="makeStyles-search-50"
+          >
+            <div
+              class="MuiFormControl-root MuiTextField-root makeStyles-input-44"
+            >
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+                data-shrink="false"
+                for="filled-search"
+                id="filled-search-label"
+              >
+                Search Here...
+              </label>
+              <div
+                class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+              >
+                <input
+                  aria-invalid="false"
+                  aria-label="search google maps"
+                  class="MuiInputBase-input MuiInput-input"
+                  id="filled-search"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <button
+              aria-label="search"
+              class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-45"
+              tabindex="0"
+              type="submit"
+            >
+              <span
+                class="MuiIconButton-label"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
           </div>
         </div>
         <table
@@ -245,7 +297,7 @@ exports[`LOST should render requestsComponent component 1`] = `
 exports[`LOST should render requestsComponent component 2`] = `
 <DocumentFragment>
   <div
-    class="MuiPaper-root makeStyles-root-204 MuiPaper-elevation1 MuiPaper-rounded"
+    class="MuiPaper-root makeStyles-root-246 MuiPaper-elevation1 MuiPaper-rounded"
   >
     <div
       class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
@@ -254,12 +306,64 @@ exports[`LOST should render requestsComponent component 2`] = `
         class="MuiTypography-root MuiTypography-h6"
         id="tableTitle"
       >
-        My requests
+        My request
+      </div>
+      <div
+        class="makeStyles-search-254"
+      >
+        <div
+          class="MuiFormControl-root MuiTextField-root makeStyles-input-248"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+            data-shrink="false"
+            for="filled-search"
+            id="filled-search-label"
+          >
+            Search Here...
+          </label>
+          <div
+            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          >
+            <input
+              aria-invalid="false"
+              aria-label="search google maps"
+              class="MuiInputBase-input MuiInput-input"
+              id="filled-search"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <button
+          aria-label="search"
+          class="MuiButtonBase-root MuiIconButton-root makeStyles-iconButton-249"
+          tabindex="0"
+          type="submit"
+        >
+          <span
+            class="MuiIconButton-label"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+              />
+            </svg>
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
       </div>
     </div>
     <table
       aria-label="caption table"
-      class="MuiTable-root makeStyles-table-205"
+      class="MuiTable-root makeStyles-table-247"
     >
       <thead
         class="MuiTableHead-root"

--- a/src/components/AvailRequestsTable.js
+++ b/src/components/AvailRequestsTable.js
@@ -54,59 +54,6 @@ const useStyles = makeStyles((theme) => ({
 	}
 }));
 
-const TablePaginationActions = (props) => {
-	const classes = useStyles1();
-	const theme = useTheme();
-	const { count, page, rowsPerPage, onChangePage } = props;
-
-	const handleFirstPageButtonClick = (event) => {
-		onChangePage(event, 0);
-	};
-
-	const handleBackButtonClick = (event) => {
-		onChangePage(event, page - 1);
-	};
-
-	const handleNextButtonClick = (event) => {
-		onChangePage(event, page + 1);
-	};
-
-	const handleLastPageButtonClick = (event) => {
-		onChangePage(event, Math.max(0, Math.ceil(count / rowsPerPage) - 1));
-	};
-
-	return (
-		<div className={classes.root}>
-			<IconButton onClick={handleFirstPageButtonClick} disabled={page === 0} aria-label="first page">
-				{theme.direction === 'rtl' ? <LastPageIcon /> : <FirstPageIcon />}
-			</IconButton>
-			<IconButton onClick={handleBackButtonClick} disabled={page === 0} aria-label="previous page">
-				{theme.direction === 'rtl' ? <KeyboardArrowRight /> : <KeyboardArrowLeft />}
-			</IconButton>
-			<IconButton
-				onClick={handleNextButtonClick}
-				disabled={page >= Math.ceil(count / rowsPerPage) - 1}
-				aria-label="next page"
-			>
-				{theme.direction === 'rtl' ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
-			</IconButton>
-			<IconButton
-				onClick={handleLastPageButtonClick}
-				disabled={page >= Math.ceil(count / rowsPerPage) - 1}
-				aria-label="last page"
-			>
-				{theme.direction === 'rtl' ? <FirstPageIcon /> : <LastPageIcon />}
-			</IconButton>
-		</div>
-	);
-};
-
-TablePaginationActions.propTypes = {
-	count: PropTypes.number.isRequired,
-	onChangePage: PropTypes.func.isRequired,
-	page: PropTypes.number.isRequired,
-	rowsPerPage: PropTypes.number.isRequired
-};
 
 const RequestsTable = () => {
 	const requests = useSelector((state) => state.availRequests);

--- a/src/components/DrawerComponents.js
+++ b/src/components/DrawerComponents.js
@@ -121,46 +121,50 @@ const DrawerComponents = ({ history, ...props }) => {
 	];
 	const user = JSON.parse(localStorage.getItem('bn-user-data'));
 
-	if (user.role === 'super_administrator') {
-		routes = [
-			...routes,
-			{
-				key: 'user-roles',
-				text: 'Set role',
-				to: '/user-roles',
-				icon: <FaUserCog style={{ width: '25px' }} />
-			}
-		];
-	} else if (user.role === 'travel_administrator' || user.role === 'accommodation_supplier') {
-		routes = [
-			...routes,
-			{
-				key: 'add-accommodation',
-				text: 'Add accommodation',
-				to: '/add-accommodation',
-				icon: <AddToPhotosIcon />
-			},
-			{
-				key: 'add-rooms',
-				text: 'Add rooms',
-				to: '/add-rooms',
-				icon: <PostAddIcon />
-			}
-		];
-	} else if (user.role === 'manager') {
-		routes = [
-			...routes,
-			{
-				key: 'avail-requests',
-				text: 'Avail Requests',
-				to: '/avail-requests',
-				icon: <FlightIcon />
-			}
-		];
-	} else if (user.role === 'requester') {
-		routes;
+	if (user) {
+		if (user.role === 'super_administrator') {
+			routes = [
+				...routes,
+				{
+					key: 'user-roles',
+					text: 'Set role',
+					to: '/user-roles',
+					icon: <FaUserCog style={{ width: '25px' }} />
+				}
+			];
+		} else if (user.role === 'travel_administrator' || user.role === 'accommodation_supplier') {
+			routes = [
+				...routes,
+				{
+					key: 'add-accommodation',
+					text: 'Add accommodation',
+					to: '/add-accommodation',
+					icon: <AddToPhotosIcon />
+				},
+				{
+					key: 'add-rooms',
+					text: 'Add rooms',
+					to: '/add-rooms',
+					icon: <PostAddIcon />
+				}
+			];
+		} else if (user.role === 'manager') {
+			routes = [
+				...routes,
+				{
+					key: 'avail-requests',
+					text: 'Avail Requests',
+					to: '/avail-requests',
+					icon: <FlightIcon />
+				}
+			];
+		} else if (user.role === 'requester') {
+			routes;
+		}
+	} else {
+		console.log('user sasasas');
+		history.push('/');
 	}
-
 	const classes = useStyles();
 	const logout = () => {
 		localStorage.removeItem('bn-user-data');

--- a/src/routes/managerRoutes.js
+++ b/src/routes/managerRoutes.js
@@ -1,26 +1,21 @@
-import React from "react";
-import { Route, Redirect } from "react-router-dom";
-import { connect } from "react-redux";
-import PropTypes from "prop-types";
+import React from 'react';
+import { Route, Redirect } from 'react-router-dom';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 const managerRoute = ({ isManager, component: Component, ...rest }) => (
-  <Route
-    {...rest}
-    render={(props) =>
-      isManager ? <Component {...props} /> : <Redirect to="/dashboard" />
-    }
-  />
+	<Route {...rest} render={(props) => (isManager ? <Component {...props} /> : <Redirect to="/dashboard" />)} />
 );
 
 managerRoute.propTypes = {
-  component: PropTypes.func.isRequired,
+	component: PropTypes.func.isRequired
 };
 
 const mapStateToProps = () => {
-  const user = JSON.parse(localStorage.getItem("bn-user-data"));
-  return {
-    isManager: user.role === "manager",
-  };
+	const user = JSON.parse(localStorage.getItem('bn-user-data'));
+	return {
+		isManager: user ? user.role === 'manager' : null
+	};
 };
 
 export default connect(mapStateToProps)(managerRoute);

--- a/src/routes/superAdminRoutes.js
+++ b/src/routes/superAdminRoutes.js
@@ -1,26 +1,21 @@
-import React from "react";
-import { Route, Redirect } from "react-router-dom";
-import { connect } from "react-redux";
-import PropTypes from "prop-types";
+import React from 'react';
+import { Route, Redirect } from 'react-router-dom';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 const superAdminRoute = ({ isSuperAdmin, component: Component, ...rest }) => (
-  <Route
-    {...rest}
-    render={(props) =>
-      isSuperAdmin ? <Component {...props} /> : <Redirect to="/dashboard" />
-    }
-  />
+	<Route {...rest} render={(props) => (isSuperAdmin ? <Component {...props} /> : <Redirect to="/dashboard" />)} />
 );
 
 superAdminRoute.propTypes = {
-  component: PropTypes.func.isRequired,
+	component: PropTypes.func.isRequired
 };
 
 function mapStateToProps() {
-  const user = JSON.parse(localStorage.getItem("bn-user-data"));
-  return {
-    isSuperAdmin: user.role === "super_administrator",
-  };
+	const user = JSON.parse(localStorage.getItem('bn-user-data'));
+	return {
+		isSuperAdmin: user ? user.role === 'super_administrator' : null
+	};
 }
 
 export default connect(mapStateToProps)(superAdminRoute);

--- a/src/routes/travelAdminRoutes.js
+++ b/src/routes/travelAdminRoutes.js
@@ -1,28 +1,21 @@
-import React from "react";
-import { Route, Redirect } from "react-router-dom";
-import { connect } from "react-redux";
-import PropTypes from "prop-types";
+import React from 'react';
+import { Route, Redirect } from 'react-router-dom';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 const travelAdminRoute = ({ isTravelAdmin, component: Component, ...rest }) => (
-  <Route
-    {...rest}
-    render={(props) =>
-      isTravelAdmin ? <Component {...props} /> : <Redirect to="/dashboard" />
-    }
-  />
+	<Route {...rest} render={(props) => (isTravelAdmin ? <Component {...props} /> : <Redirect to="/dashboard" />)} />
 );
 
 travelAdminRoute.propTypes = {
-  component: PropTypes.func.isRequired,
+	component: PropTypes.func.isRequired
 };
 
 function mapStateToProps() {
-  const user = JSON.parse(localStorage.getItem("bn-user-data"));
-  return {
-    isTravelAdmin:
-      user.role === "travel_administrator" ||
-      user.role === "accommodation_supplier",
-  };
+	const user = JSON.parse(localStorage.getItem('bn-user-data'));
+	return {
+		isTravelAdmin: user ? user.role === 'travel_administrator' || user.role === 'accommodation_supplier' : null
+	};
 }
 
 export default connect(mapStateToProps)(travelAdminRoute);

--- a/src/views/Dashboard/Requests.js
+++ b/src/views/Dashboard/Requests.js
@@ -8,8 +8,8 @@ import { getRequestsAction } from '../../redux/actions/requestsAction';
 import { withRouter } from 'react-router-dom';
 
 class Requests extends Component {
-	componentDidMount() {
-		this.props.getRequestsAction();
+	async componentDidMount() {
+		await this.props.getRequestsAction();
 	}
 	render() {
 		return (

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,88 +5,87 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const Dotenv = require('dotenv-webpack');
 
 module.exports = {
-  mode: "development",
-  devServer: {
-    historyApiFallback: {
-      disableDotRule: true,
-    },
-  },
-  entry: "./src/index",
-  stats: "errors-only",
-  output: {
-    path: path.resolve(__dirname, "build"),
-    publicPath: "/",
-    filename: "bundle.js",
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        use: ["babel-loader"],
-      },
-      {
-        test: /\.s[ac]ss$/i,
-        use: ["style-loader", "css-loader", "sass-loader"],
-      },
-      {
-        test: /\.css$/,
-        use: [
-          "style-loader",
-          {
-            loader: "css-loader",
-            options: {
-              importLoaders: 1,
-              modules: true,
-            },
-          },
-        ],
-        include: /\.module\.css$/,
-      },
-      {
-        test: /\.css$/,
-        use: ["style-loader", "css-loader"],
-        exclude: /\.module\.css$/,
-      },
-      {
-        test: /\.(png|jpe?g|gif)$/i,
-        include: path.resolve(__dirname, 'src'),
-        use: [
-          {
-            loader: 'file-loader',
-          },
-        ],
-      },
-    ],
-  },
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: "./public/index.html",
-    }),
-    new Dotenv(),
-    new webpack.DefinePlugin({
-      PRODUCTION_API: JSON.stringify(
-        "https://octopus-bn-backend.herokuapp.com/api/v1/"
-      ),
-    }),
-    new webpack.DefinePlugin({
-      DEVELOPMENT_API: JSON.stringify("http://localhost:3000/api/v1/"),
-    }),
-	new MiniCssExtractPlugin(),
-	new Dotenv({
-		path: './.env',
-		safe: true,
-		systemvars: true,
-		silent: true,
-		defaults: false,
-	  }),
-  ],
-  node: {
-	fs: 'empty',
-  },
-  resolve: {
-    alias: {
-      "react-router-dom": path.resolve("./node_modules/react-router-dom"),
-    },
-  },
+	mode: 'development',
+	devServer: {
+		port: 9000,
+		historyApiFallback: {
+			disableDotRule: true
+		}
+	},
+	entry: './src/index',
+	stats: 'errors-only',
+	output: {
+		path: path.resolve(__dirname, 'build'),
+		publicPath: '/',
+		filename: 'bundle.js'
+	},
+	module: {
+		rules: [
+			{
+				test: /\.(js|jsx)$/,
+				exclude: /node_modules/,
+				use: [ 'babel-loader' ]
+			},
+			{
+				test: /\.s[ac]ss$/i,
+				use: [ 'style-loader', 'css-loader', 'sass-loader' ]
+			},
+			{
+				test: /\.css$/,
+				use: [
+					'style-loader',
+					{
+						loader: 'css-loader',
+						options: {
+							importLoaders: 1,
+							modules: true
+						}
+					}
+				],
+				include: /\.module\.css$/
+			},
+			{
+				test: /\.css$/,
+				use: [ 'style-loader', 'css-loader' ],
+				exclude: /\.module\.css$/
+			},
+			{
+				test: /\.(png|jpe?g|gif)$/i,
+				include: path.resolve(__dirname, 'src'),
+				use: [
+					{
+						loader: 'file-loader'
+					}
+				]
+			}
+		]
+	},
+	plugins: [
+		new HtmlWebpackPlugin({
+			template: './public/index.html'
+		}),
+		new Dotenv(),
+		new webpack.DefinePlugin({
+			PRODUCTION_API: JSON.stringify('https://octopus-bn-backend.herokuapp.com/api/v1/')
+		}),
+		new webpack.DefinePlugin({
+			DEVELOPMENT_API: JSON.stringify('http://localhost:3000/api/v1/')
+		}),
+		new MiniCssExtractPlugin(),
+		new Dotenv({
+			path: './.env',
+			safe: true,
+			systemvars: true,
+			silent: true,
+			defaults: false
+		})
+	],
+	node: {
+		fs: 'empty'
+	},
+	resolve: {
+		alias: {
+			'react-router-dom': path.resolve('./node_modules/react-router-dom')
+		}
+	}
 };


### PR DESCRIPTION
	Search Function

## **Why**
As requests and approval tables grow, it should be easy to find requests through the search functionality

**As a user,** I should be able to use the search component
So, I can easily retrieve records from both the request and approval table

## **Acceptance Criteria**
- Given that a user is logged in, when the user enters data into the search component, then the records displayed in the table should reflect all possible records relevant to the content of the  data entered by the user in the search component
- User should be able to search based on the column headers which are: request ID, owner, destination, origin, duration, start date, request status etc


#### Description of Task to be completed?
- search through array

#### How should this be manually tested?

- open your terminal
- clone this repo by `git clone https://github.com/Stackup-Rwanda/octopus-bn-frontend`
- run `cd octopus-bn-frontend` to move to the project folder
- run `git checkout  ft-search-170947395` to move to this branch 
- run `npm install` to install all required dependencies for this feature
- run 'npm run dev' to start the development server 

#### Screenshots (if appropriate)
Before 

![image](https://user-images.githubusercontent.com/52036624/83410248-53c6e180-a416-11ea-8c86-1bb0ce07cc01.png)

After
![image](https://user-images.githubusercontent.com/52036624/83410187-2c701480-a416-11ea-909c-a1ae3c2997da.png)

https://www.pivotaltracker.com/story/show/170947395

[finishes #170947395]